### PR TITLE
Fix tool deselection on model switch

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -212,17 +212,13 @@
 			return;
 		}
 
-		const model = atSelectedModel ?? $models.find((m) => m.id === selectedModels[0]);
-		if (model) {
-			selectedToolIds = [
-				...new Set(
-					[...selectedToolIds, ...(model?.info?.meta?.toolIds ?? [])].filter((id) =>
-						$tools.find((t) => t.id === id)
-					)
-				)
-			];
-		}
-	};
+                const model = atSelectedModel ?? $models.find((m) => m.id === selectedModels[0]);
+                if (model) {
+                        selectedToolIds = (model?.info?.meta?.toolIds ?? []).filter((id) =>
+                                $tools.find((t) => t.id === id)
+                        );
+                }
+        };
 
 	const setFilterIds = async () => {
 		if (selectedModels.length !== 1 && !atSelectedModel) {


### PR DESCRIPTION
## Summary
- fix Chat page logic so tool IDs reset when switching models

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm run test:frontend` *(fails: vitest not found)*